### PR TITLE
fix running sklearn, `main_train_wine_quality.py` does not exist

### DIFF
--- a/sklearn/MLproject
+++ b/sklearn/MLproject
@@ -10,7 +10,7 @@ entry_points:
       alpha: float
       l1_ratio: {type: float, default: 0.1}
       run_origin: {type: string, default: "default" }
-    command: "python main_train_wine_quality.py 
+    command: "python main.py 
                 --experiment_name {experiment_name} 
                 --data_path {data_path} 
                 --alpha {alpha} 


### PR DESCRIPTION
I had to adjust this in order to get `mlflow` to run properly via the commands in your example:

```
~/src/mlflow-spark-summit-2019/sklearn$ mlflow run . -P alpha=0.01 -P l1_ratio=0.75 -P run_origin=LocalRun -P data_path=data/wine-quality-white.csv --experiment-id=2
```

`main_train_wine_quality.py` file does not exist.